### PR TITLE
Fix Hadoop 0.20, 0.21 compilation; improve handling of script dir

### DIFF
--- a/workloadSuite/GenerateReplayScript.java
+++ b/workloadSuite/GenerateReplayScript.java
@@ -1,6 +1,8 @@
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.io.File;
+import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -312,6 +314,25 @@ public class GenerateReplayScript {
                 System.err.println("All is good.");
 		System.err.println();
 	    }
+
+		// make scriptDirPath directory if it doesn't exist
+		
+		File d = new File(scriptDirPath);
+		if (d.exists()) {
+			if (d.isDirectory()) {
+				System.err.println("Warning! About to overwrite existing scripts in: " + scriptDirPath);
+				System.err.print("Ok to continue? [y/n] ");
+				BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+				String s = in.readLine();
+				if (s == null || s.length() < 1 || s.toLowerCase().charAt(0) != 'y') {
+					throw new Exception("Declined overwrite of existing directory");
+				}
+			} else {
+				throw new Exception(scriptDirPath + " is a file.");
+			}
+		} else {
+			d.mkdirs();
+		}
 
 	    // print shell scripts
 

--- a/workloadSuite/WorkGen.java
+++ b/workloadSuite/WorkGen.java
@@ -264,8 +264,8 @@ public class WorkGen extends Configured implements Tool {
 
     System.out.println("Max number of map tasks " + cluster.getMaxMapTasks());
     System.out.println("Max number of red tasks " + cluster.getMaxReduceTasks());
-    System.out.println("shuffleInputRatio  = " + jobConf.getDouble("workGen.ratios.shuffleInputRatio", 1.0d));
-    System.out.println("outputShuffleRatio = " + jobConf.getDouble("workGen.ratios.outputShuffleRatio", 1.0d));
+    System.out.println("shuffleInputRatio  = " + jobConf.getFloat("workGen.ratios.shuffleInputRatio", 1.0f));
+    System.out.println("outputShuffleRatio = " + jobConf.getFloat("workGen.ratios.outputShuffleRatio", 1.0f));
 
     System.out.println("Running on " +
         cluster.getTaskTrackers() + " nodes with " + 


### PR DESCRIPTION
Current versions of Hadoop seem to support getFloat as part of jobConf and not getDouble:
https://hadoop.apache.org/common/docs/current/api/org/apache/hadoop/conf/Configuration.html#getFloat(java.lang.String, float)

This pull request also improves the handling of the script directory as part of GenerateReplayScript. If the directory doesn't exist, it creates it. Otherwise, it confirms with the user before over-writing an existing directory.
